### PR TITLE
add window buffer limit to avoid too large state 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
           GPG_PASSWORD: ${{ secrets.GPG_KEY_PASSWORD }}
           GPG_SECRET: ${{ secrets.GPG_SECRET_KEY }}
       - name: Push Maven Artifacts to SonaType (only on Master)
-#        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository --info

--- a/core/src/test/java/com/airwallex/airskiff/flink/FlinkWindowStreamTest.java
+++ b/core/src/test/java/com/airwallex/airskiff/flink/FlinkWindowStreamTest.java
@@ -1,0 +1,56 @@
+package com.airwallex.airskiff.flink;
+
+import com.airwallex.airskiff.core.EventTimeBasedSlidingWindow;
+import com.airwallex.airskiff.testhelpers.TestFlinkConfig;
+import com.airwallex.airskiff.testhelpers.TestInputData;
+import com.airwallex.airskiff.testhelpers.TestRunner;
+import org.apache.flink.api.java.tuple.Tuple2;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import com.airwallex.airskiff.core.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FlinkWindowStreamTest {
+  /*
+  window allows max lateness is min(1 day, 14 * slide)
+  when day 0 arrives, state keeps data of day 0
+  when day 1 arrives, state keeps data of day 0, 1
+  when day 4 arrives, state keeps data of day 4, delete data of day 0, 1
+  when day 1 arrives again, state keeps data of day 4, 1
+   */
+  @Test
+  public void testWindowSlide() throws Exception {
+    List<Tuple2<Long, TestInputData>> data = new ArrayList<>();
+    data.add(new Tuple2<>(0L, new TestInputData(1, "1")));
+    data.add(new Tuple2<>(Duration.ofDays(1).toMillis(), new TestInputData(1, "1")));
+    data.add(new Tuple2<>(Duration.ofDays(4).toMillis(), new TestInputData(1, "1")));
+    data.add(new Tuple2<>(Duration.ofDays(1).toMillis(), new TestInputData(1, "1")));
+    var config = new TestFlinkConfig<>(data, TestInputData.class);
+    var source = new SourceStream<>(config);
+    TestRunner runner = new TestRunner();
+    var stream = runner.realtimeCompiler.compile(
+      source.keyBy(t -> t.b, String.class)
+        .window(new EventTimeBasedSlidingWindow(Duration.ofDays(1), Duration.ofDays(1)), it -> {
+          // simple sum for TestInputData of last one day
+          TestInputData aggregatedData = new TestInputData(0, "");
+          for (TestInputData id : it) {
+            aggregatedData.a += id.a;
+            aggregatedData.b = id.b;
+          }
+          ArrayList<TestInputData> result = new ArrayList<>();
+          result.add(aggregatedData);
+          return result;
+        }, TestInputData::compareTo, TestInputData.class).values()
+    );
+    var result = stream.executeAndCollect(4);
+    assertEquals(4, result.size());
+    assertEquals(1, result.get(0).f1.a);
+    assertEquals(2, result.get(1).f1.a);
+    assertEquals(1, result.get(2).f1.a);
+    assertEquals(1, result.get(3).f1.a);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=com.airwallex.airskiff
 name=core
-version=2.0.52
+version=2.0.53
 org.gradle.daemon=true
 org.gradle.parallel=true
 file.encoding=utf-8


### PR DESCRIPTION
when users use Window Function, they always don't understand what the slide means and set 1 day as slide when window size is 1 day. 
It results in too large state and checkpoints of flink.
I hope add buffer limit to 1 day at most.